### PR TITLE
Add direct message models

### DIFF
--- a/app/models/depot.rb
+++ b/app/models/depot.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# ## Schema Information
+#
+# Table name: `depots`
+#
+# ### Columns
+#
+# Name                 | Type               | Attributes
+# -------------------- | ------------------ | ---------------------------
+# **`id`**             | `bigint`           | `not null, primary key`
+# **`receiver_type`**  | `string`           | `not null`
+# **`created_at`**     | `datetime`         | `not null`
+# **`updated_at`**     | `datetime`         | `not null`
+# **`receiver_id`**    | `bigint`           | `not null`
+#
+# ### Indexes
+#
+# * `index_depots_on_receiver` (_unique_):
+#     * **`receiver_type`**
+#     * **`receiver_id`**
+#
+class Depot < ApplicationRecord
+  belongs_to :receiver, polymorphic: true
+end

--- a/app/models/depot/user.rb
+++ b/app/models/depot/user.rb
@@ -20,18 +20,7 @@
 #     * **`receiver_type`**
 #     * **`receiver_id`**
 #
-class Depot < ApplicationRecord
-  # Treat the polymorphic type column as the STI type as well
-  #
-  # This allows us to customize behavior via a subclass keeping our interfaces and associations
-  # cleaner.
-  self.inheritance_column = "receiver_type"
-  self.store_full_sti_class = false
-
-  # TODO: Add protections to prevent this receiver association from being swapped after creation
-  belongs_to :receiver, polymorphic: true
-
-  validates :receiver_id, on: :create, uniqueness: { scope: :receiver_type }
-
-  validates :receiver_type, presence: true
+class Depot::User < Depot
+  validates :receiver_type,
+            inclusion: { in: %w[User], message: "must be User" }
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# ## Schema Information
+#
+# Table name: `messages`
+#
+# ### Columns
+#
+# Name              | Type               | Attributes
+# ----------------- | ------------------ | ---------------------------
+# **`id`**          | `bigint`           | `not null, primary key`
+# **`content`**     | `string(4000)`     | `not null`
+# **`created_at`**  | `datetime`         | `not null`
+# **`updated_at`**  | `datetime`         | `not null`
+# **`author_id`**   | `bigint`           | `not null`
+# **`depot_id`**    | `bigint`           | `not null`
+#
+# ### Indexes
+#
+# * `index_messages_on_author_id`:
+#     * **`author_id`**
+# * `index_messages_on_depot_id`:
+#     * **`depot_id`**
+#
+# ### Foreign Keys
+#
+# * `fk_rails_995937c106` (_ON DELETE => cascade_):
+#     * **`author_id => users.id`**
+# * `fk_rails_e0b15f1a9c`:
+#     * **`depot_id => depots.id`**
+#
+class Message < ApplicationRecord
+  # TODO: Add protections to prevent the author association from being swapped after creation
+  belongs_to :author, class_name: "User", inverse_of: :authored_messages
+
+  # TODO: Add protections to prevent the depot association from being swapped after creation
+  belongs_to :depot
+
+  validates :content,
+            presence: true,
+            length: { maximum: 4_000 }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,4 +43,12 @@ class User < ApplicationRecord
   validates :name,
             presence: true,
             length: { maximum: 400 }
+
+  # TODO: Promote this to a customized association/scope to support eager loading
+  def messages
+    query = authored_messages
+    query = query.or(direct_depot.messages) if direct_depot
+
+    query
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,13 @@
 class User < ApplicationRecord
   has_one :direct_depot, class_name: "Depot::User", as: :receiver, dependent: :delete
 
+  # TODO: Is there a better domain term for this? (compositions?)
+  has_many :authored_messages,
+           class_name: "Message",
+           foreign_key: :author_id,
+           inverse_of: :author,
+           dependent: :delete_all
+
   validates :handle,
             presence: true,
             length: { maximum: 120 },

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,8 @@
 #     * **`lower((handle)::text)`**
 #
 class User < ApplicationRecord
+  has_one :direct_depot, class_name: "Depot::User", as: :receiver, dependent: :delete
+
   validates :handle,
             presence: true,
             length: { maximum: 120 },

--- a/db/migrate/20220311061736_create_depots.rb
+++ b/db/migrate/20220311061736_create_depots.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateDepots < ActiveRecord::Migration[7.0]
+  def change
+    create_table :depots do |t|
+      t.references :receiver, polymorphic: true, null: false, index: { unique: true }
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20220311141521_create_messages.rb
+++ b/db/migrate/20220311141521_create_messages.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateMessages < ActiveRecord::Migration[7.0]
+  def change
+    create_table :messages do |t|
+      t.references :author,
+                   null: false,
+                   foreign_key: { to_table: :users, on_delete: :cascade },
+                   index: true
+
+      t.references :depot, null: false, foreign_key: true, index: true
+
+      t.string :content, limit: 4000, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_10_180742) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_11_061736) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "depots", force: :cascade do |t|
+    t.string "receiver_type", null: false
+    t.bigint "receiver_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["receiver_type", "receiver_id"], name: "index_depots_on_receiver", unique: true
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "handle", limit: 120, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_11_061736) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_11_141521) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_11_061736) do
     t.index ["receiver_type", "receiver_id"], name: "index_depots_on_receiver", unique: true
   end
 
+  create_table "messages", force: :cascade do |t|
+    t.bigint "author_id", null: false
+    t.bigint "depot_id", null: false
+    t.string "content", limit: 4000, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["author_id"], name: "index_messages_on_author_id"
+    t.index ["depot_id"], name: "index_messages_on_depot_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "handle", limit: 120, null: false
     t.string "name", limit: 400, null: false
@@ -30,4 +40,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_11_061736) do
     t.index "lower((handle)::text)", name: "index_users_on_LOWER_handle", unique: true
   end
 
+  add_foreign_key "messages", "depots"
+  add_foreign_key "messages", "users", column: "author_id", on_delete: :cascade
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 #
@@ -6,3 +7,14 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+
+author = User.create!(handle: "the-real-author", name: "Any Author")
+friend = User.create!(handle: "your-friend", name: "Any Friend")
+_no_dms = User.create!(handle: "no-sliding-into-my-dms!", name: "No DMs")
+
+dm_author = author.create_direct_depot!
+dm_friend = friend.create_direct_depot!
+
+author.authored_messages.create!(depot: dm_author, content: "Is this thing on?")
+author.authored_messages.create!(depot: dm_friend, content: "Hello? Can you hear me?")
+friend.authored_messages.create!(depot: dm_author, content: "Can you hear me?")

--- a/doc/adr/20220310190424-data-models-messages.md
+++ b/doc/adr/20220310190424-data-models-messages.md
@@ -1,0 +1,357 @@
+# 20220310190424. Data Models: Messages
+
+Date: 2022-03-10
+
+Service/Subsystem(s): Messages
+
+
+## Status
+
+Status: Proposed <!-- Proposed | Accepted | Rejected -->
+
+
+## References
+
+- [Feature: Direct messages][1]
+- [Feature: Stream messages][2]
+- [Feature: Topic messages][3]
+- [Feature: Group messages][4]
+
+
+## Problem Statement and Context
+
+We need to create data models to map the core text message object(s) and their associations. The
+initial goal of the data modeling is to implement the [direct messages][1].
+
+
+### Decision Drivers
+
+The current road map lists four main features related to messages:
+
+- [Direct messages][1]
+- [Stream messages][2]
+- [Topic messages][3]
+- [Group messages][4]
+
+There is some ambiguity as to if topic and group messages are really all that different. Since all
+of these are on the road map we need to keep them in mind when we develop the design. We need to do
+that so that we can do our best, given our time constraints, to make design steps that support these
+longer term goals. Worst case, we make an informed trade-off that is a lateral step, but we really
+don't want to pick a design that will send us backwards.
+
+
+## Future State / Proposal
+
+### Database Structure
+
+```mermaid
+erDiagram
+  USERS {
+      bigint id PK
+  }
+
+  GROUPS {
+      bigint id PK
+  }
+
+  MESSAGES {
+      bigint id PK
+      bigint author_id FK "users.id"
+      bigint depository_id "depositories.id"
+      string content
+  }
+
+  DEPOSITORIES {
+      bigint id PK
+      bigint deposit_id "users.id OR groups.id"
+      string deposit_type "User OR Group"
+  }
+
+  USERS ||--o{ MESSAGES : "authors"
+  USERS ||--|| DEPOSITORIES : "DIRECT depository"
+  GROUPS ||--o{ DEPOSITORIES : "GROUP depository"
+  DEPOSITORIES ||--o{ MESSAGES : "receives"
+```
+
+This proposal utilizes a polymorphic associations and an additional entity in an attempt to balance
+complexity, future extensibility and data integrity.
+
+We lose data integrity with the polymorphic association (i.e. no foreign keys). We attempt to gain
+some of that back by introducing the additional `depositories` entity which we anticipate to have a
+much lower cardinality than `messages`.
+
+However, this design builds in flexibility for the planned future expansion into streams, topic
+groups and private groups.
+
+### Model Attributes: Messages
+
+All primary keys will use the Rails default of `bigint`. As this is 8 bytes that should provide us
+enough runway for some time; even for the core `messages` table.
+
+At a high level a `Message` is composed of:
+
+- An `author` (`User` whom created the message)
+- Text content (Max length: TBD - see decision below)
+- A `Depository` (Target destination of the message)
+
+  If `Message` was a letter, the `Depository` would where you are sending it.
+
+In terms of columns we have:
+
+- `id`: Standard incrementing primary key (required)
+- `author_id`: The foreign key for the ID of the user authoring the message
+
+  We will use the domain term author in the data to help reduce confusion when discussing messages.
+  "Author" clearly states which party of the message to which we may be referring.
+- `depository_id`: The foreign key for the `Depository`
+
+  Using the letter analogy, this is the address of the letter. And the actual end building is the
+  depository itself.
+- `content`: The actual message text
+
+
+## Alternatives and Options Explored
+
+### Model Attributes
+
+The following additional `Message` attributes were considered:
+
+- `authored_at`: Record when a message was "authored" (aka created locally by the client)
+- `received_at`: Record when a message was "received" (aka downloaded by the client)
+- `deleted_at`: Soft delete a message
+
+  Outstanding questions about `deleted_at`:
+  - Can only the author delete?
+  - If a DMer is abusive, what recourse is there for the receiver to no longer see the DMs?
+  - Does each side need to be able to control their view?
+
+### Naming
+
+For the "author" role the following alternative names are up for consideration (in alphabetical
+order and not order of preference):
+
+- composer
+- creator
+- originator
+- sender
+- source
+- writer
+
+For the "depository" role:
+
+- destination
+- receiver
+- recipient
+- target
+
+For the "message.content" attribute:
+
+- body
+- composition
+- message
+- missive
+- quotation
+- text
+
+### Database Structure
+
+For the below alternative designs the column names were not finalized. See the _Naming_ section for
+detailed discussion around the name aspects.
+
+#### Alternative Design 1
+
+```mermaid
+erDiagram
+  USERS {
+      bigint id PK
+  }
+
+  DIRECT_MESSAGES {
+      bigint id PK
+      bigint sender_id FK "users.id"
+      bigint receiver_id FK "users.id"
+      string text
+  }
+
+  USERS ||--o{ DIRECT_MESSAGES : sends
+  USERS ||--o{ DIRECT_MESSAGES : receives
+```
+
+This is a very simple and direct design. However, it is highly tailored to direct messages only.
+Given the road map it is likely this design may lead to heavy data migrations to accommodate the
+other types of planned messages...OR depending on future choices it could lead to duplication of
+core message attributes and validations across multiple tables (e.g. a table for each type of
+message).
+
+#### Alternative Design 2
+
+```mermaid
+erDiagram
+  USERS {
+      bigint id PK
+  }
+
+  DIRECT_MESSAGES {
+      bigint id PK
+      bigint receiever_id FK "users.id"
+      bigint message_id FK "messages.id"
+  }
+
+  MESSAGES {
+      bigint id PK
+      bigint sender_id FK "users.id"
+      string content
+  }
+
+  USERS ||--o{ DIRECT_MESSAGES : receives
+  USERS ||--o{ MESSAGES : sends
+  MESSAGES ||--|| DIRECT_MESSAGES : ""
+```
+
+This recognizes the downside for duplication of core message logic across tables. It makes the core
+message a first class entity and treats the direct message as an association entity. However, as
+with the first alternative design this will either require multiple tables or extensive data
+migrations to handle future message types.
+
+#### Alternative Design 3
+
+```mermaid
+erDiagram
+  USERS {
+      bigint id PK
+  }
+
+  GROUPS {
+      bigint id PK
+  }
+
+  MESSAGES {
+      bigint id PK
+      bigint author_id FK "users.id"
+      bigint recipient_id "users.id OR groups.id"
+      string recipient_type "User OR Group"
+      string content
+  }
+
+  USERS ||--o{ MESSAGES : "authors"
+  USERS ||--o{ MESSAGES : "receives DMs"
+  GROUPS ||--o{ MESSAGES : "receives"
+```
+
+This intentionally is not flushing out how we will implement the various groups. Instead it is
+including some concept of "group" (_handy wavey_) to guide the design. By using polymorphism all
+messages are contained to a single table. This should make queries straight forward. However,
+polymorphism prevents data integrity through foreign keys. Given the expected high cardinality of
+`messages` this could prove to be a long term maintenance nightmare.
+
+#### Alternative Design 4
+
+```mermaid
+erDiagram
+  USERS {
+      bigint id PK
+  }
+
+  GROUPS {
+      bigint id PK
+  }
+
+  MESSAGES {
+      bigint id PK
+      bigint author_id FK "users.id"
+      bigint dm_recipient_id FK "users.id"
+      bigint group_id FK "groups.id"
+      string recipient_type "User OR Group"
+      string content
+  }
+
+  USERS ||--o{ MESSAGES : "authors"
+  USERS ||--o{ MESSAGES : "receives DMs"
+  GROUPS ||--o{ MESSAGES : "receives"
+```
+
+This is a variation on alternative design 3. Instead of polymorphism this utilizes multiple columns,
+one for each of the potential relations. This solves the data integrity issue. However, if it turns
+out we have more than just user and group relations (e.g. our assumptions about consolidating the
+other messages times doesn't pan out or we get some new type we don't know about) then we'll need to
+add a new column per relation. That has scaling issues long term which need to be kept in mind.
+
+_**NOTE:** If we want to use single table inheritance (STI) we can change `recipient_type` to
+`type`. We can further improve data integrity by utilizing multiple conditional constraints to
+ensure that `dm_recipient_id` and `group_id` are each only set in accordance with the type._
+
+#### Alternative Design Association Variations
+
+```mermaid
+erDiagram
+  MESSAGES {
+      bigint id PK
+      bigint author_id FK "users.id"
+      bigint deposit_id FK "depositories.deposit_id"
+      string deposit_type FK "depositories.deposit_type"
+      string content
+  }
+
+  DEPOSITORIES {
+      bigint id PK
+      bigint deposit_id "users.id OR groups.id"
+      string deposit_type "User OR Group"
+  }
+
+  DEPOSITORIES ||--o{ MESSAGES : "receives"
+```
+
+This utilizes a multi-column foreign key (compound / composite key) on `messages`:
+
+```sql
+FOREIGN KEY (deposit_id, deposit_type) REFERENCES depositories(deposit_id, deposit_type)
+```
+
+This type of foreign key doesn't play nicely with Rails without a bit of customization for the
+defined associations. That is definitely a bump in ease of use on the code side.
+
+But, this does maintain the data integrity between the tables. And this can provide some
+alternatives to avoid the extra SQL joins.
+
+## Decision
+
+**TL;DR; Short summary sentence of the final decision**
+
+<!--
+This section resolves questions raised under the Alternatives heading. It is a clear statement of
+what the team has settled on as the most appropriate solution to the problem under consideration.
+
+Be sure to include _why_ the decision was made in comparison to the alternatives and options
+presented above. As part of the _why_ behind the decision, the reasoning behind accepting any and
+all disadvantages or trade-offs of the chosen solution need to be clearly addressed in this section.
+
+Additionally, it is good to include information about _how_ decision drivers impacted the choice. As
+well as, what influence the history and long term architecture goals had on this decision.
+-->
+
+
+## Consequences
+
+<!--
+This section is intended to be a quick reference for later and thus should matter of factly state
+the advantages and disadvantages of the decision. For example, what are the long term impacts? What
+things do people need to keep in mind moving forward?
+
+People can reference the Context and Decision sections for the _why_ behind it all.
+
+Finally, make it clear in what the expectations are for other engineers. Do they need to start
+making changes in their applications to reflect the decision? Do they need to make a change to their
+way of working, or their toolchain? How can they get started? In short, what do teams need to do to
+fulfill the requirements of the ADR?
+
+This is also a good time to highlight any sort of follow-up items which are required. For example,
+was any part of the decision punted on? Are there glaring unknowns which are being left until a
+later time?
+-->
+
+
+
+[1]: https://github.com/cupakromer/message_swagger/issues/2
+[2]: https://github.com/cupakromer/message_swagger/issues/3
+[3]: https://github.com/cupakromer/message_swagger/issues/4
+[4]: https://github.com/cupakromer/message_swagger/issues/5

--- a/spec/fixtures/depots.yml
+++ b/spec/fixtures/depots.yml
@@ -20,20 +20,6 @@
 #     * **`receiver_type`**
 #     * **`receiver_id`**
 #
-class Depot < ApplicationRecord
-  # Treat the polymorphic type column as the STI type as well
-  #
-  # This allows us to customize behavior via a subclass keeping our interfaces and associations
-  # cleaner.
-  self.inheritance_column = "receiver_type"
-  self.store_full_sti_class = false
 
-  # TODO: Add protections to prevent this receiver association from being swapped after creation
-  belongs_to :receiver, polymorphic: true
-
-  has_many :messages, dependent: :delete_all
-
-  validates :receiver_id, on: :create, uniqueness: { scope: :receiver_type }
-
-  validates :receiver_type, presence: true
-end
+dm_friend:
+  receiver: friend (User)

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# ## Schema Information
+#
+# Table name: `users`
+#
+# ### Columns
+#
+# Name              | Type               | Attributes
+# ----------------- | ------------------ | ---------------------------
+# **`id`**          | `bigint`           | `not null, primary key`
+# **`handle`**      | `string(120)`      | `not null`
+# **`name`**        | `string(400)`      | `not null`
+# **`created_at`**  | `datetime`         | `not null`
+# **`updated_at`**  | `datetime`         | `not null`
+#
+# ### Indexes
+#
+# * `index_users_on_LOWER_handle` (_unique_):
+#     * **`lower((handle)::text)`**
+#
+author:
+  handle: the-real-author
+  name: Any Author
+
+friend:
+  handle: wontUBmyneighbor
+  name: Your Friend

--- a/spec/models/depot/user_spec.rb
+++ b/spec/models/depot/user_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Depot::User, type: :model do
+  describe "validating a record" do
+    subject(:valid_depot) {
+      Depot::User.new(receiver: any_user)
+    }
+
+    let(:any_user) { build(User) }
+
+    before do
+      expect(valid_depot).to be_valid
+    end
+
+    it "TODO: Include the Depot validation tests here to as they are inherited"
+
+    it "requires an approved receiver type" do
+      # Shoulda matchers doesn't work for STI in this manner due to STI requiring the value to be a
+      # known constant
+      expect {
+        valid_depot.receiver_type = "ApplicationRecord"
+      }.to change {
+        valid_depot.valid?
+      }.from(true).to(false).and change {
+        valid_depot.errors[:receiver_type]
+      }.to include("must be User")
+    end
+  end
+end

--- a/spec/models/depot_spec.rb
+++ b/spec/models/depot_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Depot, type: :model do
+  describe "validating a record" do
+    subject(:valid_depot) {
+      Depot.new(receiver: any_receiver)
+    }
+
+    let(:any_receiver) { build(User) }
+
+    before do
+      expect(valid_depot).to be_valid
+    end
+
+    it "requires a receiver" do
+      expect(valid_depot).to belong_to(:receiver).required
+    end
+
+    it "validates the receiver is unique on creation" do
+      expect(valid_depot).to(
+        validate_uniqueness_of(:receiver_id)
+        .scoped_to(:receiver_type)
+        .on(:create)
+      )
+    end
+
+    it "requires a receiver type" do
+      expect(valid_depot).to validate_presence_of(:receiver_type)
+    end
+  end
+end

--- a/spec/models/depot_spec.rb
+++ b/spec/models/depot_spec.rb
@@ -30,4 +30,16 @@ RSpec.describe Depot, type: :model do
       expect(valid_depot).to validate_presence_of(:receiver_type)
     end
   end
+
+  describe "messages association", pending: "TODO: Skipping due to time constraints" do
+    it "may have many"
+
+    it "only includes messages for this depot"
+
+    it "deletes all the messages when the depot is deleted"
+
+    # Inverse associations are important for helping to reduce memory overhead and unexpected N+1
+    # queries
+    it "has a correct inverse association"
+  end
 end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Message, type: :model do
+  describe "validating a record" do
+    fixtures :depots, :users
+
+    subject(:valid_message) {
+      build(
+        Message,
+        author: any_author,
+        depot: any_depot,
+        content: "Any valid message",
+      )
+    }
+
+    let(:any_author) { users(:author) }
+
+    let(:any_depot) { depots(:dm_friend) }
+
+    before do
+      expect(valid_message).to be_valid
+    end
+
+    it "requires an author" do
+      expect(valid_message).to belong_to(:author).required
+    end
+
+    it "requires a depot" do
+      expect(valid_message).to belong_to(:depot).required
+    end
+
+    it "requires some content" do
+      expect(valid_message).to validate_presence_of(:content)
+    end
+
+    it "requires some content" do
+      expect(valid_message).to validate_presence_of(:content)
+    end
+
+    it "requires content to be less than 4,000 characters" do
+      expect(valid_message).to validate_length_of(:content).is_at_most(4_000)
+    end
+
+    it "supports unicode content" do
+      long_unicode_content = "🍱" * 4_000
+
+      expect {
+        valid_message.content = long_unicode_content
+      }.not_to change {
+        valid_message.valid?
+      }.from(true)
+
+      expect(valid_message.save!).to eq(true)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -59,4 +59,16 @@ RSpec.describe User, type: :model do
       expect(valid_user.save!).to eq(true)
     end
   end
+
+  describe "direct depot association", pending: "TODO: Skipping due to time constraints" do
+    it "has only one"
+
+    it "supports no association set"
+
+    it "deletes the association when the user is deleted"
+
+    # Inverse associations are important for helping to reduce memory overhead and unexpected N+1
+    # queries
+    it "has a correct inverse association"
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -83,4 +83,39 @@ RSpec.describe User, type: :model do
     # queries
     it "has a correct inverse association"
   end
+
+  describe "fetching all messages" do
+    fixtures :depots, :users
+
+    let(:author) { users(:author) }
+
+    let(:friend) { users(:friend) }
+
+    it "includes messages authored by the user" do
+      authored_message = author.authored_messages.create!(
+        depot: friend.direct_depot,
+        content: "Hello Friend",
+      )
+
+      expect(author.messages).to include(authored_message)
+    end
+
+    it "includes messages to the user's DM depot" do
+      received_dm = author.authored_messages.create!(
+        depot: friend.direct_depot,
+        content: "Hello Friend",
+      )
+
+      expect(friend.messages).to include(received_dm)
+    end
+
+    it "does not include messages authored by another user for a non-subscribed depot" do
+      non_author_dm = friend.authored_messages.create!(
+        depot: friend.direct_depot,
+        content: "Friendly note to self",
+      )
+
+      expect(author.messages).not_to include(non_author_dm)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -71,4 +71,16 @@ RSpec.describe User, type: :model do
     # queries
     it "has a correct inverse association"
   end
+
+  describe "authored messages association", pending: "TODO: Skipping due to time constraints" do
+    it "may have many"
+
+    it "only includes messages authored by the user"
+
+    it "deletes all the messages when the user is deleted"
+
+    # Inverse associations are important for helping to reduce memory overhead and unexpected N+1
+    # queries
+    it "has a correct inverse association"
+  end
 end

--- a/spec/support/model_factories.rb
+++ b/spec/support/model_factories.rb
@@ -4,8 +4,15 @@ require 'radius/spec/model_factory'
 
 Radius::Spec::ModelFactory.catalog do |c|
   c.factory(
+    "Message",
+    author: :required,
+    depot: :required,
+    content: "Any message text",
+  )
+
+  c.factory(
     "User",
-    handle: "any-handle",
+    handle: -> { "any-handle#{rand(100_000)}" },
     name: "Any Name",
   )
 end


### PR DESCRIPTION
_Work towards #2_

This sets up the basic data models per [ADR 20220310190424](https://github.com/cupakromer/message_swagger/blob/cupakromer-add-direct-message-models/doc/adr/20220310190424-data-models-messages.md). Refer to that extensive write-up for details on all the design decisions.

Due to time constraints various stages of unit tests have been omitted. Similarly, some robust guarding for data integrity and security was omitted due to time constraints. Follow-up issues have been created to track circling back to these: #8 and #9