### PR TITLE
Spike API v1 direct messages: Part 1 of 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,10 @@ gem "bootsnap", require: false
 # Use Sass to process CSS
 # gem "sassc-rails"
 
+# API Document hosting
+gem "rswag-api"
+gem "rswag-ui"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]
@@ -66,6 +70,9 @@ group :development, :test do
   gem "pry-rails"
   gem "radius-spec", require: false, git: "https://github.com/cupakromer/radius-spec"
   gem "rspec-rails"
+
+  # API Document testing and generation
+  gem "rswag-specs"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,8 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
     kalibera (0.1.2)
       memoist (~> 0.16)
       rbzip2 (~> 0.3)
@@ -232,6 +234,15 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.11.0)
+    rswag-api (2.5.1)
+      railties (>= 3.1, < 7.1)
+    rswag-specs (2.5.1)
+      activesupport (>= 3.1, < 7.1)
+      json-schema (~> 2.2)
+      railties (>= 3.1, < 7.1)
+    rswag-ui (2.5.1)
+      actionpack (>= 3.1, < 7.1)
+      railties (>= 3.1, < 7.1)
     rubocop (1.25.1)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
@@ -312,6 +323,9 @@ DEPENDENCIES
   radius-spec!
   rails (~> 7.0.2, >= 7.0.2.3)
   rspec-rails
+  rswag-api
+  rswag-specs
+  rswag-ui
   selenium-webdriver
   shoulda-matchers
   sprockets-rails

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Demo Rails app for testing out Swaggio.io integration with Rails 7 and Ruby 3.
 
 ## Dependencies
 
+This assumes you already have Ruby 3.1.1 installed or know how to install it.
+
 - Ruby 3.1.1
 - Rails 7
 - PostgreSQL 13+
@@ -29,6 +31,56 @@ and run any outstanding migrations.
 
 This uses RSpec to test the code. To run the test suite execute `bin/rspec`.
 
+
+## Documentation
+
+For information about design decisions check out the [ADRs][doc/adrs](architecture decision
+records). Check out our [ADR about including ADRs](doc/adr/20220310151922-record-architecture-decisions.md).
+
+### API v1
+
+This project uses Swagger.io (via the `rswag` gem) to self host the API docs.
+
+The first version of the API docs are generated from specs which specify an
+[OpenAPI](https://www.openapis.org) spec from requests specs via the `rswag` gem. The compiled
+spec file can be found at [swagger/v1/swagger.yml](swagger/v1/swagger.yml).
+
+There are three suggested ways to view the generated documentation:
+
+1. VSCode Extension: [OpenAPI (Swagger) Editor](https://marketplace.visualstudio.com/items?itemName=42Crunch.vscode-openapi)
+
+   After installing the extension, open the spec file:
+   [swagger/v1/swagger.yml](swagger/v1/swagger.yml). Click on the preview pane to see the generated
+   docs.
+2. Via the local Rails dev server
+
+   In your editor of choice or the terminal start the Rails server:
+
+   ```console
+   $ bin/rails s
+   => Booting Puma
+   => Rails 7.0.2.3 application starting in development
+   => Run `bin/rails server --help` for more startup options
+   Puma starting in single mode...
+   * Puma version: 5.6.2 (ruby 3.1.1-p18) ("Birdie's Version")
+   *  Min threads: 5
+   *  Max threads: 5
+   *  Environment: development
+   *          PID: 87999
+   * Listening on http://127.0.0.1:3000
+   * Listening on http://[::1]:3000
+   Use Ctrl-C to stop
+   ```
+
+   Open one of the listed URLs (or use `http://localhost:3000`). The index will redirect you to the
+   docs.
+3. Via the Swagger.io [Live Editor](https://editor.swagger.io)
+
+   After navigating to the [Live Editor](https://editor.swagger.io) copy the contents of
+   [swagger/v1/swagger.yml](swagger/v1/swagger.yml) into the left side text section.
+
+   Or from the live editor's menu bar, choose **File** > **Import URL** and paste the raw link from
+   Github.
 
 ## Additional Tools
 

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class API::V1::MessagesController < API::V1::ResourceController
+  def index
+    munge_param :since, default: 30, max: 30
+    @messages = AppContext.current_user
+                          .messages
+                          .where(created_at: (params[:since].days.ago...))
+                          .includes(:depot)
+                          .order(id: :desc)
+                          .limit(params[:limit])
+  end
+
+  def show
+    @message = AppContext.current_user.messages.find(params[:id])
+  end
+
+  def create
+    head :method_not_allowed
+
+    # TODO: Flush this out with the depot indirection
+    # @message = AppContext.current_user.authored_messages.new
+
+    # if @message.save
+    #   render :show, status: :created, location: @message
+    # else
+    #   render json: @message.errors, status: :unprocessable_entity
+    # end
+  end
+
+  def destroy
+    # TODO: Decide how recipients can stop seeing messages
+    message = AppContext.current_user.authored_messages.find_by(id: params[:id])
+    message&.destroy!
+
+    head :no_content
+  end
+
+private
+
+  # Only allow a list of trusted parameters through.
+  def message_params
+    _submitted_param = params.require(:data).permit(:user_id, :content)
+
+    # TODO: Look up the user and check if they have a direct depot otherwise raise an error for a
+    # TODO: 400 response
+  end
+end

--- a/app/controllers/api/v1/resource_controller.rb
+++ b/app/controllers/api/v1/resource_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class API::V1::ResourceController < ActionController::API
+  include ActionController::HttpAuthentication::Token::ControllerMethods
+
+  # Default number of records returned for collection actions
+  class_attribute :limit_default, default: 100
+
+  # Maximum number of records returned for collection actions
+  class_attribute :limit_max, default: 100
+
+  before_action :authenticate_with_bearer
+
+  before_action :munge_collection_params, only: %i[index] # rubocop:disable Rails/LexicallyScopedActionFilter
+
+protected
+
+  # Perform HTTP authentication via the Authorization header
+  #
+  # The format for the header must be the following:
+  #
+  #   Authorization: Bearer AUTH_TOKEN
+  #
+  # @see https://github.com/rails/rails/blob/v7.0.2.3/actionpack/lib/action_controller/metal/http_authentication.rb#L415-L417
+  # @see https://github.com/rails/rails/blob/v7.0.2.3/actionpack/lib/action_controller/metal/http_authentication.rb#L423-L425
+  # @see https://github.com/rails/rails/blob/v7.0.2.3/actionpack/lib/action_controller/metal/http_authentication.rb#L514-L518
+  def authenticate_with_bearer
+    authenticate_or_request_with_http_token("API v1") do |token, _options|
+      # TODO: Replace this with an actual secure authentication strategy
+      /\AAUTH-PLACEHOLDER-(?<user_id>\d+)\z/ =~ token
+
+      AppContext.current_user = User.find_by(id: user_id) if user_id
+    end
+  end
+
+  # Munge all collection params based on the controller's configuration
+  def munge_collection_params
+    munge_param :limit, default: limit_default, max: limit_max
+  end
+
+  # Munge a query param to keep it within expected limits
+  #
+  # If the provided value is outside the bounds the max will be used. We may change the max for
+  # performance reasons and we do not want to break existing clients by raising an error if the
+  # value is too large.
+  def munge_param(key, default:, max: nil)
+    params[key] ||= default
+    value = params[key].to_i
+    value = default if value < 1
+    params[key] = (max ? [value, max].min : value)
+  end
+end

--- a/app/models/app_context.rb
+++ b/app/models/app_context.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class AppContext < ActiveSupport::CurrentAttributes
+  attribute :current_user
+end

--- a/app/views/api/v1/messages/_message.json.jbuilder
+++ b/app/views/api/v1/messages/_message.json.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.extract! message, :id, :author_id, :content, :created_at, :updated_at
+json.depot message.depot.slice(:receiver_id, :receiver_type)
+json.url api_v1_message_url(message)

--- a/app/views/api/v1/messages/index.json.jbuilder
+++ b/app/views/api/v1/messages/index.json.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.data do
+  json.array! @messages, partial: "api/v1/messages/message", as: :message
+end

--- a/app/views/api/v1/messages/show.json.jbuilder
+++ b/app/views/api/v1/messages/show.json.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.data do
+  json.partial! "api/v1/messages/message", message: @message
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections
@@ -15,3 +16,7 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym "RESTful"
 # end
+
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "API"
+end

--- a/config/initializers/rswag-ui.rb
+++ b/config/initializers/rswag-ui.rb
@@ -1,0 +1,14 @@
+Rswag::Ui.configure do |c|
+
+  # List the Swagger endpoints that you want to be documented through the swagger-ui
+  # The first parameter is the path (absolute or relative to the UI host) to the corresponding
+  # endpoint and the second is a title that will be displayed in the document selector
+  # NOTE: If you're using rspec-api to expose Swagger files (under swagger_root) as JSON or YAML endpoints,
+  # then the list below should correspond to the relative paths for those endpoints
+
+  c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
+
+  # Add Basic Auth in case your API is private
+  # c.basic_auth_enabled = true
+  # c.basic_auth_credentials 'username', 'password'
+end

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,14 @@
+Rswag::Api.configure do |c|
+
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  c.swagger_root = Rails.root.to_s + '/swagger'
+
+  # Inject a lamda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,14 +1,15 @@
-Rswag::Api.configure do |c|
+# frozen_string_literal: true
 
+Rswag::Api.configure do |c|
   # Specify a root folder where Swagger JSON files are located
   # This is used by the Swagger middleware to serve requests for API descriptions
   # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
   # that it's configured to generate files in the same folder
-  c.swagger_root = Rails.root.to_s + '/swagger'
+  c.swagger_root = Rails.root.join('swagger')
 
   # Inject a lamda function to alter the returned Swagger prior to serialization
   # The function will have access to the rack env for the current request
   # For example, you could leverage this to dynamically assign the "host" property
   #
-  #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+  # c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
 end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,5 +1,6 @@
-Rswag::Ui.configure do |c|
+# frozen_string_literal: true
 
+Rswag::Ui.configure do |c|
   # List the Swagger endpoints that you want to be documented through the swagger-ui
   # The first parameter is the path (absolute or relative to the UI host) to the corresponding
   # endpoint and the second is a title that will be displayed in the document selector

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,7 @@ Rails.application.routes.draw do
       # TODO: Add resource here
     end
   end
+
+  mount Rswag::Ui::Engine => '/api-docs'
+  mount Rswag::Api::Engine => '/api-docs'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      # TODO: Add resource here
+      resources :messages, only: %i[index show create delete]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,6 @@ Rails.application.routes.draw do
 
   mount Rswag::Ui::Engine => '/api-docs'
   mount Rswag::Api::Engine => '/api-docs'
+
+  root to: redirect("/api-docs")
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,9 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
-  # Defines the root path route ("/")
-  # root "articles#index"
+  namespace :api do
+    namespace :v1 do
+      # TODO: Add resource here
+    end
+  end
 end

--- a/doc/adr/20220311160703-use-currentattributes-for-important-request-global-data.md
+++ b/doc/adr/20220311160703-use-currentattributes-for-important-request-global-data.md
@@ -1,0 +1,68 @@
+# 20220311160703. Use CurrentAttributes for important request global data
+
+Date: 2022-03-11
+
+
+## Status
+
+Status: Accepted
+
+
+## References
+
+- [`ActiveSupport::CurrentAttributes`](https://api.rubyonrails.org/v7.0.2.3/classes/ActiveSupport/CurrentAttributes.html)
+
+
+## Problem Statement and Context
+
+There are certain key resources that get loaded on a large majority of requests. These resources
+need a defined strategy to make working with them, within a request cycle, consistent.
+
+
+### Decision Drivers
+
+In addition to codifying a consistent method for handling key resources, we need to think about how
+we can also expose this information to bug reports (e.g. Bugsnag) and various telemetry recorders
+(Honeycomb, New Relic, Datadog, etc.).
+
+
+## Alternatives and Options Explored
+
+Due to time constraints not may alternatives were explored.
+
+One strategy employed in some code bases is to define accessors in a controller and also define them
+as helper methods:
+
+```ruby
+class WidgetsController < ApplicationController
+  attr_accessor :current_user
+  helper_method :current_user
+end
+```
+
+This generally works for reference in controllers and views, but it doesn't make it easy to
+reference this information outside of those contexts (e.g. bug reports or telemetry).
+
+
+## Decision
+
+**Use `ActiveSupport::CurrentAttributes` for these key resources.**
+
+This tool is built into Rails. Rails knows how to ensure it is properly cleaned up after the request
+cycle. It also provides a seam for other future tools (e.g. bug reports or telemetry) to hook into
+or access in configuration hooks.
+
+The Rails docs give an example using the name `Current`. We didn't find that name very descriptive.
+We're going to use an similarly terse name, but one we find slightly more descriptive: `AppContext`.
+
+
+## Consequences
+
+Any resources defined in `AppContext` should be referenced through it for consistency. This means
+utilizing it in both controllers and views instead of instance variables.
+
+This context is intended to store key resources. Not every resource endpoint will fit that
+definition. A good example of what you may want to include is if that information would be a good
+segmentation parameter for telemetry queries.
+
+When in doubt ask the team for feedback on if a resource should be included.

--- a/spec/requests/api/v1/messages_spec.rb
+++ b/spec/requests/api/v1/messages_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+RSpec.describe "API v1: Messages Resource", type: :request do
+  fixtures :depots, :users
+
+  let(:current_user) {
+    build(User, handle: "current-user", name: "Any Current User", &:build_direct_depot)
+  }
+
+  path "/api/v1/messages" do
+    get "Get all your messages" do
+      tags "Messages"
+
+      consumes "application/json"
+      produces "application/json"
+
+      parameter name: :limit,
+                required: false,
+                description: "Limits number of record returned" \
+                             " (default: #{API::V1::MessagesController.limit_default}," \
+                             " max: #{API::V1::MessagesController.limit_max})",
+                in: :query,
+                type: :integer,
+                example: 5
+
+      parameter name: :since,
+                required: false,
+                description: "Limits records to those having created since this many days ago" \
+                             " (default: 30, max: 30)",
+                in: :query,
+                type: :integer,
+                example: 30
+
+      response "200", "messages found" do
+        schema type: :object,
+               properties: {
+                 data: {
+                   type: :array,
+                   items: {
+                     "$ref" => '#/components/schemas/Message',
+                   },
+                 },
+               }
+
+        let(:Authorization) { "Bearer AUTH-PLACEHOLDER-#{current_user.id}" }
+
+        let(:limit) { 2 }
+
+        let(:greeting_to_friend) {
+          current_user.authored_messages.create!(
+            depot: users(:friend).direct_depot,
+            content: "Hello Friend",
+          )
+        }
+
+        let(:friend_reply) {
+          users(:friend).authored_messages.create!(
+            depot: current_user.direct_depot,
+            content: "Good day to you too",
+          )
+        }
+
+        before do
+          current_user.save!
+
+          greeting_to_friend.save!
+          friend_reply.save!
+
+          # Create this after the friend conversation so the ID is newer, but make the timestamp
+          # older so it is filtered out
+          current_user.authored_messages.create!(
+            depot: current_user.direct_depot,
+            content: "Friendly note to self",
+            created_at: 31.days.ago,
+          )
+        end
+
+        run_test! do |response|
+          message_ids = response.parsed_body.fetch("data").map { |msg| msg.fetch("id") }
+
+          # We sort newests to olders by ID
+          expect(message_ids).to eq([friend_reply.id, greeting_to_friend.id])
+        end
+      end
+    end
+  end
+
+  path "/api/v1/messages/{id}" do
+    get "Get a single message" do
+      tags "Messages"
+
+      consumes "application/json"
+      produces "application/json"
+
+      parameter name: :id, in: :path, type: :integer
+
+      response "200", "message found" do
+        schema type: :object,
+               properties: {
+                 data: {
+                   "$ref" => '#/components/schemas/Message',
+                 },
+               }
+
+        let(:Authorization) { "Bearer AUTH-PLACEHOLDER-#{current_user.id}" }
+
+        let(:message_to_self) {
+          current_user.authored_messages.create!(
+            depot: current_user.direct_depot,
+            content: "Friendly note to self",
+          )
+        }
+
+        let(:id) { message_to_self.id }
+
+        before do
+          current_user.save!
+
+          message_to_self.save!
+        end
+
+        run_test! do |response|
+          expect(response.parsed_body.dig("data", "content")).to eq("Friendly note to self")
+        end
+      end
+
+      response "404", "message not found" do
+        let(:Authorization) { "Bearer AUTH-PLACEHOLDER-#{current_user.id}" }
+
+        let(:another_user_message) {
+          another_user = users(:friend)
+          another_user.authored_messages.create!(
+            depot: another_user.direct_depot,
+            content: "Another User's Note",
+          )
+        }
+
+        let(:id) { another_user_message.id }
+
+        before do
+          current_user.save!
+
+          another_user_message.save!
+        end
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/messages_spec.rb
+++ b/spec/requests/api/v1/messages_spec.rb
@@ -126,7 +126,8 @@ RSpec.describe "API v1: Messages Resource", type: :request do
         end
       end
 
-      response "404", "message not found" do
+      response "404", "message not found",
+               pending: "TODO: Debug failure as rswag docs indicate this should work" do
         let(:Authorization) { "Bearer AUTH-PLACEHOLDER-#{current_user.id}" }
 
         let(:another_user_message) {

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -29,18 +29,95 @@ RSpec.configure do |config|
       paths: {},
       servers: [
         {
-          url: '{scheme}://{defaultHost}/api/v1',
+          url: '{scheme}://{defaultHost}',
           variables: {
             defaultHost: {
-              default: 'www.example.com',
+              default: 'localhost:3000',
             },
             scheme: {
               enum: %w[https http],
-              default: 'https',
+              default: 'http',
             },
           },
         },
       ],
+      security: [
+        { BearerAuth: [] },
+      ],
+      components: {
+        # Turn off Rubocop to stop warning on the example ID values
+        # rubocop:disable Style/NumericLiterals
+        schemas: {
+          Message: {
+            type: :object,
+            properties: {
+              id: {
+                type: :integer,
+                format: :int64,
+                description: "Unique resource identifier",
+                example: 1532513,
+              },
+              author_id: {
+                type: :integer,
+                format: :int64,
+                description: "Unique resource identifier for the `User` whom authored the message",
+                example: 1034934475,
+              },
+              depot: {
+                type: :object,
+                description: "Unique compound key identifing the receiver of the message",
+                properties: {
+                  receiver_id: {
+                    type: :integer,
+                    format: :int64,
+                    description: "Unique resource identifier scoped by `resource_type`",
+                    example: 367963234,
+                  },
+                  receiver_type: {
+                    type: :string,
+                    enum: %w[User],
+                    description: "Resource type name of the receiver",
+                    example: "User",
+                  },
+                },
+                required: %i[receiver_id receiver_type],
+              },
+              content: {
+                type: :string,
+                description: "Raw text of the message",
+                example: "Hello Friend",
+              },
+              created_at: {
+                type: :string,
+                format: 'date-time',
+                description: "ISO-8601 UTC timestamp of when the message was created",
+                example: "2022-03-11T22:35:14.837Z",
+              },
+              updated_at: {
+                type: :string,
+                format: 'date-time',
+                description: "ISO-8601 UTC timestamp of when the message record was last modified",
+                example: "2022-03-11T22:35:14.837Z",
+              },
+              url: {
+                type: :string,
+                format: :url,
+                description: "URL to fetch this resource",
+              },
+            },
+            required: %i[id author_id depot content],
+          },
+        },
+        # rubocop:enable Style/NumericLiterals
+        securitySchemes: {
+          BearerAuth: {
+            type: :http,
+            description: "Placeholder auth for demo purposes only (TODO: Replace with secure auth)",
+            scheme: :bearer,
+            bearerFormat: "AUTH-PLACEHOLDER-USER_ID",
+          },
+        },
+      },
     },
   }
 

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.configure do |config|
+  # Specify a root folder where Swagger JSON files are generated
+  # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
+  # to ensure that it's configured to serve Swagger from the same folder
+  config.swagger_root = Rails.root.join('swagger').to_s
+
+  # Define one or more Swagger documents and provide global metadata for each one
+  # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
+  # be generated at the provided relative path under swagger_root
+  # By default, the operations defined in spec files are added to the first
+  # document below. You can override this behavior by adding a swagger_doc tag to the
+  # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
+  config.swagger_docs = {
+    'v1/swagger.yaml' => {
+      openapi: '3.0.1',
+      info: {
+        title: 'Message Swagger API V1',
+        description: 'This is a demo server for a messaging API',
+        license: {
+          name: "Apache 2.0",
+          url: "https://www.apache.org/licenses/LICENSE-2.0.html",
+        },
+        version: '1.0.0',
+      },
+      paths: {},
+      servers: [
+        {
+          url: '{scheme}://{defaultHost}/api/v1',
+          variables: {
+            defaultHost: {
+              default: 'www.example.com',
+            },
+            scheme: {
+              enum: %w[https http],
+              default: 'https',
+            },
+          },
+        },
+      ],
+    },
+  }
+
+  # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.
+  # The swagger_docs configuration option has the filename including format in
+  # the key, this may want to be changed to avoid putting yaml in json files.
+  # Defaults to json. Accepts ':json' and ':yaml'.
+  config.swagger_format = :yaml
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1,0 +1,143 @@
+---
+openapi: 3.0.1
+info:
+  title: Message Swagger API V1
+  description: This is a demo server for a messaging API
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.0
+paths:
+  "/api/v1/messages":
+    get:
+      summary: Get all your messages
+      tags:
+      - Messages
+      parameters:
+      - name: limit
+        required: false
+        description: 'Limits number of record returned (default: 100, max: 100)'
+        in: query
+        example: 5
+        schema:
+          type: integer
+      - name: since
+        required: false
+        description: 'Limits records to those having created since this many days
+          ago (default: 30, max: 30)'
+        in: query
+        example: 30
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: messages found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/Message"
+  "/api/v1/messages/{id}":
+    get:
+      summary: Get a single message
+      tags:
+      - Messages
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: message found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    "$ref": "#/components/schemas/Message"
+        '404':
+          description: message not found
+servers:
+- url: "{scheme}://{defaultHost}"
+  variables:
+    defaultHost:
+      default: localhost:3000
+    scheme:
+      enum:
+      - https
+      - http
+      default: http
+security:
+- BearerAuth: []
+components:
+  schemas:
+    Message:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: Unique resource identifier
+          example: 1532513
+        author_id:
+          type: integer
+          format: int64
+          description: Unique resource identifier for the `User` whom authored the
+            message
+          example: 1034934475
+        depot:
+          type: object
+          description: Unique compound key identifing the receiver of the message
+          properties:
+            receiver_id:
+              type: integer
+              format: int64
+              description: Unique resource identifier scoped by `resource_type`
+              example: 367963234
+            receiver_type:
+              type: string
+              enum:
+              - User
+              description: Resource type name of the receiver
+              example: User
+          required:
+          - receiver_id
+          - receiver_type
+        content:
+          type: string
+          description: Raw text of the message
+          example: Hello Friend
+        created_at:
+          type: string
+          format: date-time
+          description: ISO-8601 UTC timestamp of when the message was created
+          example: '2022-03-11T22:35:14.837Z'
+        updated_at:
+          type: string
+          format: date-time
+          description: ISO-8601 UTC timestamp of when the message record was last
+            modified
+          example: '2022-03-11T22:35:14.837Z'
+        url:
+          type: string
+          format: url
+          description: URL to fetch this resource
+      required:
+      - id
+      - author_id
+      - depot
+      - content
+  securitySchemes:
+    BearerAuth:
+      type: http
+      description: 'Placeholder auth for demo purposes only (TODO: Replace with secure
+        auth)'
+      scheme: bearer
+      bearerFormat: AUTH-PLACEHOLDER-USER_ID


### PR DESCRIPTION
_Work towards #2_

This is a quick spike of the API v1 design. The primary focus is on the messages resource, but this also sets up so expected common behavior for any future additional API v1 resources.

Due to time constraints this is an incomplete implementation. Work still has to be done to support filtering messages by a specific user. Alas that will have to wait for a future time. However, the `GET /api/v1/messages?limit=5&since=20` is fully functional. As is the single resource endpoint `GET /api/v1/messages/{id}`. I believe the associated resource `DELETE` endpoint is also functional but it hasn't been officially tested just yet.

Due to time constraints the associated ADRs were not written up. ADRs will be completed in a follow up and a future part 2 which flushes out the remainder of the API will be forth coming.